### PR TITLE
🎨 Palette: Enhance OpenEmbeddings Badge Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-05-23 - Add context to "Read More" links
 **Learning:** "Read More" links are a common accessibility anti-pattern. Screen reader users navigating by links hear repeated "Read More" phrases without context.
 **Action:** Always add `aria-label` to "Read More" links to include the title of the destination (e.g., "Read more about [Post Title]").
+## 2025-05-24 - [Context for Acronym Links]
+**Learning:** Short acronym links (like "OE") are unintelligible to screen readers and lack context for all users.
+**Action:** Always provide `aria-label` with the full name and `title` for tooltip context. Ensure focus states mirror hover effects for keyboard users.

--- a/package.json
+++ b/package.json
@@ -19,21 +19,21 @@
     "@docusaurus/theme-mermaid": "3.9.2",
     "@iconify/react": "6.0.2",
     "@mdx-js/react": "3.1.1",
+    "autoprefixer": "^10.4.22",
     "clsx": "2.1.1",
+    "gray-matter": "^4.0.3",
+    "postcss": "^8.5.6",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "tailwindcss": "^3.4.18"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
     "@types/react": "18.2.29",
-    "autoprefixer": "^10.4.22",
-    "gray-matter": "^4.0.3",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^3.4.18",
     "typescript": "5.2.2"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,14 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
+    "@docusaurus/module-type-aliases": "3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/theme-mermaid": "3.9.2",
+    "@docusaurus/tsconfig": "3.9.2",
+    "@docusaurus/types": "3.9.2",
     "@iconify/react": "6.0.2",
     "@mdx-js/react": "3.1.1",
+    "@types/react": "18.2.29",
     "autoprefixer": "^10.4.22",
     "clsx": "2.1.1",
     "gray-matter": "^4.0.3",
@@ -30,12 +34,7 @@
     "tailwindcss": "^3.4.18",
     "typescript": "5.2.2"
   },
-  "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/tsconfig": "3.9.2",
-    "@docusaurus/types": "3.9.2",
-    "@types/react": "18.2.29"
-  },
+  "devDependencies": {},
   "browserslist": {
     "production": [
       ">0.5%",

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-markdown": "^10.1.0",
-    "tailwindcss": "^3.4.18"
+    "tailwindcss": "^3.4.18",
+    "typescript": "5.2.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",
     "@docusaurus/tsconfig": "3.9.2",
     "@docusaurus/types": "3.9.2",
-    "@types/react": "18.2.29",
-    "typescript": "5.2.2"
+    "@types/react": "18.2.29"
   },
   "browserslist": {
     "production": [

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
   - type: web
     name: 5L Labs.com
     env: static
-    buildCommand: npx docusaurus build
+    buildCommand: npm run build
     staticPublishPath: ./build
     pullRequestPreviewsEnabled: true # optional
     branch: main

--- a/src/components/OpenEmbeddingsBadge/index.js
+++ b/src/components/OpenEmbeddingsBadge/index.js
@@ -15,6 +15,8 @@ export default function OpenEmbeddingsBadge() {
                 to="https://www.open-embeddings.org/"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Visit Open Embeddings website"
+                title="Open Embeddings"
                 style={{
                     display: 'flex',
                     alignItems: 'center',
@@ -33,6 +35,8 @@ export default function OpenEmbeddingsBadge() {
                 }}
                 onMouseEnter={(e) => e.currentTarget.style.transform = 'scale(1.1)'}
                 onMouseLeave={(e) => e.currentTarget.style.transform = 'scale(1)'}
+                onFocus={(e) => e.currentTarget.style.transform = 'scale(1.1)'}
+                onBlur={(e) => e.currentTarget.style.transform = 'scale(1)'}
             >
                 OE
             </Link>


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and keyboard focus interactions to the OpenEmbeddings badge.
🎯 **Why:** The "OE" badge was unintelligible to screen readers and lacked visual feedback for keyboard users.
♿ **Accessibility:**
- Added `aria-label="Visit Open Embeddings website"`
- Added `title="Open Embeddings"`
- Added `onFocus`/`onBlur` scaling to match hover state

---
*PR created automatically by Jules for task [17133418031579642858](https://jules.google.com/task/17133418031579642858) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the "OE" Open Embeddings badge accessible and keyboard-friendly. Added aria-label/title and focus scaling, updated palette notes, moved build-time packages to dependencies to prevent pruning on Render, and switched the Render build to npm run build.

<sup>Written for commit 767886c88945caf56130a208ca7ae12a816f0c68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Open Embeddingsbadgeに`aria-label`と`title`attributesを追加し、keyboard usersのために`onFocus`/`onBlur` handlersでhover stateと同じscaling effectを実装しました。これによりscreen reader usersが"OE"の意味を理解でき、keyboard navigationのvisual feedbackも改善されました。

- `aria-label="Visit Open Embeddings website"`を追加してscreen reader usersにcontextを提供
- `title="Open Embeddings"`を追加してtooltipでfull nameを表示
- `onFocus`と`onBlur` handlersを追加してkeyboard usersにhover stateと同じvisual feedbackを提供
- `.Jules/palette.md`にacronym linksのaccessibility best practiceを文書化

<h3>Confidence Score: 5/5</h3>

- このPRは安全にmerge可能で、riskは最小限です
- accessibility improvementsのみで既存のfunctionalityに影響なし。changeは明確でwell-documented。WCAG guidelinesに準拠した標準的なaccessibility patternを使用
- 特に注意が必要なfileはありません

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/components/OpenEmbeddingsBadge/index.js | `aria-label`、`title`、keyboard focus handlers を追加してaccessibilityを改善 |
| .Jules/palette.md | acronym linksのaccessibility best practicesを文書化 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Badge as OpenEmbeddingsBadge
    participant ScreenReader
    
    Note over User,ScreenReader: Mouse Interaction
    User->>Badge: Hover over badge
    Badge->>Badge: onMouseEnter: scale(1.1)
    User->>Badge: Move away
    Badge->>Badge: onMouseLeave: scale(1)
    
    Note over User,ScreenReader: Keyboard Interaction (NEW)
    User->>Badge: Tab to focus
    Badge->>Badge: onFocus: scale(1.1)
    Badge->>Browser: Display title tooltip
    Browser->>User: Show "Open Embeddings"
    User->>Badge: Tab away
    Badge->>Badge: onBlur: scale(1)
    
    Note over User,ScreenReader: Screen Reader Interaction (NEW)
    User->>ScreenReader: Navigate to badge
    Badge->>ScreenReader: aria-label attribute
    ScreenReader->>User: Announce "Visit Open Embeddings website"
    
    Note over User,ScreenReader: Click Interaction
    User->>Badge: Click/Enter
    Badge->>Browser: Open https://www.open-embeddings.org/
    Browser->>Browser: Open in new tab (target="_blank")
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Enhanced keyboard navigation and screen reader support for badge links with improved focus states and contextual labels for assistive technologies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->