### PR TITLE
⚡ Bolt: Optimize latest post generation to O(1) file reads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-05-24 - Client-side Markdown Rendering for Static Previews
 **Learning:** Using client-side markdown parsers (like react-markdown) for static content previews significantly increases bundle size unnecessarily. Processing markdown to plain text or HTML at build time is a much more efficient strategy for static site generators.
 **Action:** Always check if content transformation can be moved to the build step before importing heavy runtime libraries.
+
+## 2026-02-08 - O(N) File Reads in Build Script
+**Learning:** The `generate-latest-post.js` script was reading file content during the search for the latest post, making build time proportional to the number of posts.
+**Action:** Separate metadata collection from content reading. Scan filenames first, sort, then read only the winner.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@iconify/react": "6.0.2",
     "@mdx-js/react": "3.1.1",
     "clsx": "2.1.1",
+    "gray-matter": "^4.0.3",
     "prism-react-renderer": "2.4.1",
     "react": "19.2.0",
     "react-dom": "19.2.0",
@@ -31,7 +32,6 @@
     "@docusaurus/types": "3.9.2",
     "@types/react": "18.2.29",
     "autoprefixer": "^10.4.22",
-    "gray-matter": "^4.0.3",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.18",
     "typescript": "5.2.2"


### PR DESCRIPTION
Optimized `scripts/generate-latest-post.js` to separate metadata collection from content reading.
This change ensures that only the single latest file is read and parsed, optimizing file I/O from O(N) to O(1).
Verified that the generated `src/generated/latest-post.json` remains correct.
Added a journal entry to `.jules/bolt.md`.

---
*PR created automatically by Jules for task [303425658292610105](https://jules.google.com/task/303425658292610105) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized latest post generation to read only the latest file, reducing file I/O from O(N) to O(1) with unchanged output. Also ensured production builds by moving a required module to dependencies.

- **Refactors**
  - Separated metadata scanning from content reading.
  - Sorted posts by date (desc) with filename tie-breaker for deterministic selection.
  - Verified src/generated/latest-post.json matches previous output.
  - Added a journal entry to .jules/bolt.md.

- **Dependencies**
  - Moved gray-matter from devDependencies to dependencies to prevent missing module in Render production builds.

<sup>Written for commit 5c1b07132369610228dc22c79823843a31dfc5ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

