### PR TITLE
feat(ui): add focus styles to open embeddings badge

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -20,3 +20,7 @@
 ## 2026-02-08 - Dependencies for Production Build
 **Learning:** Build tools like `tailwindcss`, `postcss`, and `autoprefixer` are often needed during the production build of static sites. If they are in `devDependencies`, `bun install --production` (default on platforms like Render) will skip them, causing build failures.
 **Action:** Move build-critical tools from `devDependencies` to `dependencies` in `package.json` to ensure they are available in the production environment.
+
+## 2026-02-09 - Focus Indicators for Custom Interactive Elements
+**Learning:** Custom-styled interactive elements (like fixed badges) often lose default browser focus outlines or have insufficient contrast.
+**Action:** Always add explicit `:focus-visible` styles (e.g., `outline`, `box-shadow`, `transform`) to ensure keyboard users can clearly see where they are navigating.

--- a/src/components/OpenEmbeddingsBadge/styles.module.css
+++ b/src/components/OpenEmbeddingsBadge/styles.module.css
@@ -26,3 +26,9 @@
   transform: scale(1.1);
   color: white !important;
 }
+
+.badgeLink:focus-visible {
+  outline: 3px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+  transform: scale(1.1);
+}


### PR DESCRIPTION
- Added `:focus-visible` styles to `OpenEmbeddingsBadge` to ensure keyboard accessibility.
- The badge now displays a solid outline (`var(--ifm-color-primary)`) with an offset and scales up when focused, matching the hover effect.
- Updated `.Jules/palette.md` with the accessibility learning.
- Verified changes with Playwright script (screenshot attached in verification step).

---
*PR created automatically by Jules for task [9682359927817742050](https://jules.google.com/task/9682359927817742050) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added :focus-visible styles to OpenEmbeddingsBadge to make keyboard focus clear and match the hover state. Focus now shows a 3px primary outline with 2px offset and scales the badge to 1.1x; updated Jules/palette.md with an accessibility note.

<sup>Written for commit 4c9e1e777b2d459cc71fe9298f1829fe41a695f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

