### PR TITLE
[Render Test] Standardized Tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "node scripts/prepare-build.js && docusaurus start",
-    "build": "node scripts/prepare-build.js && docusaurus build",
+    "start": "bun scripts/prepare-build.js && docusaurus start",
+    "build": "bun scripts/prepare-build.js && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/render.yaml
+++ b/render.yaml
@@ -3,7 +3,7 @@ services:
   - type: web
     name: 5L Labs.com
     env: static
-    buildCommand: npm install && npm run build
+    buildCommand: bun install && bun run build
     staticPublishPath: ./build
     pullRequestPreviewsEnabled: true # optional
     branch: main

--- a/scripts/prepare-build.js
+++ b/scripts/prepare-build.js
@@ -9,7 +9,7 @@ const generatePostScript = path.join(__dirname, 'generate-latest-post.js');
 console.log(`Executing ${generatePostScript}...`);
 try {
     // Use execFileSync to execute the script directly without a shell for safety
-    execFileSync('node', [generatePostScript], { stdio: 'inherit' });
+    execFileSync('bun', [generatePostScript], { stdio: 'inherit' });
 } catch (error) {
     console.error('Failed to run generate-latest-post.js:', error);
     process.exit(1);


### PR DESCRIPTION
Triggering Render preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch build tooling to Bun for local development and Render previews. This makes builds consistent and should be faster across environments.

- **Refactors**
  - package.json start/build scripts now run prepare-build with Bun.
  - prepare-build.js executes generate-latest-post.js using Bun.
  - Render build pipeline uses bun install and bun run build.

<sup>Written for commit 6adde1be83a2613501d5e1b322890204d7139476. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build toolchain to use Bun runtime instead of Node.js across development and deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->