### PR TITLE
🎨 Palette: Conditionally spread accessibility attributes for external links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,8 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-02 - Dynamic Link Attributes
+
+**Learning:** When dynamically rendering `<Link>` components, simply inserting attributes like `target="_blank"` or `aria-label` inside a loop can accidentally pollute internal links with external behaviors or unnecessary labels.
+**Action:** Use an object spread with a conditional (e.g., `{...(isExternal ? { target: "_blank", rel: "noopener noreferrer", "aria-label": \`\${title} (opens in a new tab)\`, title: title } : {})}`) to apply specific accessibility and behavioral attributes only when appropriate, keeping the DOM clean and accessible.

--- a/src/components/HomepageContent/index.js
+++ b/src/components/HomepageContent/index.js
@@ -61,7 +61,11 @@ function Section({ title, items }) {
                 <div style={{ marginBottom: '0.25rem' }}>
                   <strong>
                     {item.link ? (
-                      <Link to={item.link} className="inline-flex items-center gap-1 group">
+                      <Link
+                        to={item.link}
+                        className="inline-flex items-center gap-1 group"
+                        {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer', 'aria-label': `${item.title} (opens in a new tab)`, title: item.title } : {})}
+                      >
                         {item.title}
                         {isExternal ? (
                           <ExternalLinkIcon className="transition-transform group-hover:translate-x-1 group-hover:-translate-y-1 group-focus-visible:translate-x-1 group-focus-visible:-translate-y-1" />


### PR DESCRIPTION
💡 **What**: Refactored the `<Link>` rendering in the `Section` component of `HomepageContent` to conditionally apply external link attributes (`target`, `rel`, `aria-label`, and `title`). Added a journal entry detailing this pattern.

🎯 **Why**: When mapping through items that could be internal or external links, blindly applying `target="_blank"` or `aria-label` pollutes internal links with external behaviors, resulting in a suboptimal user and screen reader experience. Using an object spread with a conditional safely injects the properties only when `isExternal` is true.

♿ **Accessibility**: 
- Added an explicit `aria-label` ("<Title> (opens in a new tab)") and `title` for hover tooltips. 
- Ensured internal links do not get unnecessary attributes.

---
*PR created automatically by Jules for task [7149072514855432525](https://jules.google.com/task/7149072514855432525) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Conditionally apply external link attributes in HomepageContent’s Section links to improve accessibility and keep internal links clean. Also adds a Palette journal entry documenting the pattern.

- **Refactors**
  - Use a conditional spread to set target="_blank", rel="noopener noreferrer", aria-label, and title only when a link is external.
  - Screen readers now announce “opens in a new tab” for external links; added guidance in `.Jules/palette.md`.

<sup>Written for commit e75b70697ad1aeaea0c1a6f9974a47325f038b00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

