### PR TITLE
🎨 Palette: Homepage Accessibility and Meta Description Fixes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-01 - External Links and Interactive Icons
 **Learning:** Setting `aria-hidden="true"` on custom external link icons prevents screen readers from announcing that the link opens in a new tab. Additionally, using only `hover` classes on interactive icons within a link omits keyboard users from seeing the same visual interactions.
 **Action:** Always assign `role="img"` and `aria-label="(opens in new tab)"` to SVG icons indicating external links. Furthermore, apply equivalent `focus-visible` classes to any hover interactions inside interactive elements to ensure visual feedback parity for keyboard users.
+
+## 2026-03-05 - Redundant Alt Text for Logos Near Headings
+**Learning:** Providing descriptive alt text (like "[Company] Logo") when the image is placed immediately next to a heading (`<h1>`) containing the exact same text causes a redundant and repetitive experience for screen reader users (e.g., "5L Labs Logo, 5L Labs").
+**Action:** When a logo image is purely illustrative and its informational content is already present in immediately adjacent text, add `alt=""` and `aria-hidden="true"` to hide the redundant image from screen readers.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,8 @@ function HomepageHeader() {
           {/* Explicit width/height to prevent CLS and ensure proper aspect ratio */}
           <img
             src={Logo}
-            alt="5L Labs Logo"
+            alt=""
+            aria-hidden="true"
             style={{ height: '150px' }}
             width={138}
             height={150}
@@ -35,10 +36,7 @@ function HomepageHeader() {
 export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
-    >
+    <Layout description={siteConfig.tagline}>
       <HomepageHeader />
       <main>
         <HomepageContent />


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Fixed redundant alt text on the 5L Labs logo in the homepage header and improved the placeholder SEO meta description. Added a new journal entry to `.Jules/palette.md` to document the accessibility learning.

### 🎯 Why: The user problem it solves
The logo image (`<img alt="5L Labs Logo">`) sits immediately next to an `<h1>` heading containing "5L Labs". Screen readers would redundantly announce "5L Labs Logo, 5L Labs". Additionally, the homepage was using the Docusaurus boilerplate description ("Description will go into a meta tag in <head />") which provides poor context for SEO and social sharing.

### 📸 Before/After: Screenshots if visual change
No visual changes.

### ♿ Accessibility: Any a11y improvements made
Applied `alt=""` and `aria-hidden="true"` to the redundant logo to streamline the screen reader experience. Improved metadata description using the `siteConfig.tagline`.

---
*PR created automatically by Jules for task [11423926198942996902](https://jules.google.com/task/11423926198942996902) started by @NickJLange*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Screen readers no longer announce the 5L Labs logo twice, and the homepage now uses the site tagline as its meta description. Documented the accessibility learning in `.Jules/palette.md`.

- **Bug Fixes**
  - Set `alt=""` and `aria-hidden="true"` on the header logo image adjacent to `<h1>`.
  - Replaced boilerplate description with `siteConfig.tagline` via `<Layout description={siteConfig.tagline}>`.

<sup>Written for commit f95d041c1b7a74b1aa830b4f0ede1f6fdcb630ef. Summary will update on new commits. <a href="https://cubic.dev/pr/NickJLange/5l-labs.com/pull/120?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

